### PR TITLE
Make the vinyl file available as template variable.

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -23,5 +23,11 @@
         <li>Secure</li>
     </ul>
 </section>
+<footer>
+    <p>
+        Source file: index.twig<br>
+        Target file: index.html
+    </p>
+</footer>
 </body>
 </html>

--- a/example/layout.twig
+++ b/example/layout.twig
@@ -14,5 +14,11 @@
 <section>
     {% block page %}{% endblock %}
 </section>
+<footer>
+    <p>
+        Source file: {{ _file.relative }}<br>
+        Target file: {{ _target.relative }}
+    </p>
+</footer>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -50,11 +50,17 @@ module.exports = function (options) {
             Twig.extend(options.extend);
             delete options.extend;
         }
+        var data = options.data || {};
+        data._file   = file;
+        data._target = {
+            path: rext(file.path, '.html'),
+            relative: rext(file.relative, '.html')
+        };
 
         template = twig(twigOpts);
 
         try {
-            file.contents = new Buffer(template.render(options.data));
+            file.contents = new Buffer(template.render(data));
         }catch(e){
             if (options.errorLogToConsole) {
                 gutil.log(PLUGIN_NAME + ' ' + e);


### PR DESCRIPTION
The vinyl file is now available as `_file` variable. The `_target` variable has two properties, the `_target.path` contains the full target path and `_target.relative` contains the relative target path.

I find this really useful, when piping multiple templates through gulp like this:
```javascript
gulp.task('build-pages', function () {
    return gulp
        .src(['pages/**/*.twig'], {base: 'pages'})
        .pipe(twig(...))
        ...;
});
```