### PR TITLE
should accept data from gulp-data plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ module.exports = function (options) {
     }
 
     function modifyContents(file, cb) {
+
+        var data = file.data || options.data || {};
+
         if (file.isNull()) {
             return cb(null, file);
         }
@@ -54,7 +57,7 @@ module.exports = function (options) {
         template = twig(twigOpts);
 
         try {
-            file.contents = new Buffer(template.render(options.data));
+            file.contents = new Buffer(template.render(data));
         }catch(e){
             if (options.errorLogToConsole) {
                 gutil.log(PLUGIN_NAME + ' ' + e);

--- a/test/main.js
+++ b/test/main.js
@@ -70,4 +70,29 @@ describe('gulp-twig', function () {
         twg.write(fakeFile);
     });
 
+    it('should accept data from file.data', function (done) {
+        var twg = twig();
+
+        var fakeFile = new gutil.File({
+            base: 'test/',
+            cwd: 'test/',
+            path: path.join(__dirname, '/templates/file.twig'),
+            contents: fs.readFileSync(__dirname + '/templates/file.twig'),
+        });
+
+        // simulate data attribute being added by gulp-data plugin
+        fakeFile['data'] = {
+            title: 'twig'
+        };
+
+        twg.on('data', function (newFile) {
+            should.exist(newFile);
+            should.exist(newFile.contents);
+            should.exist(newFile.path);
+            String(newFile.contents).should.equal(fs.readFileSync(__dirname + '/expected/file.html', 'utf8'));
+            done();
+        });
+        twg.write(fakeFile);
+    });
+
 });


### PR DESCRIPTION
I want to use gulp-twig but I need to be able to pass data to it not through the options param but through the gulp-data plugin. See [gulp-data](https://www.npmjs.com/package/gulp-data) for more detail.