### PR TITLE
Added changeExt option to avoid changing file extension to .html

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,10 +23,17 @@ module.exports = function (options) {
         }
         
         data._file   = file;
-        data._target = {
-            path: rext(file.path, '.html'),
-            relative: rext(file.relative, '.html')
-        };
+        if(options.changeExt == false){
+            data._target = {
+                 path: file.path,
+                 relative: file.relative
+             }           
+        }else{
+            data._target = {
+                path: rext(file.path, '.html'),
+                relative: rext(file.relative, '.html')
+            }
+        }
 
         var Twig = require('twig'),
             twig = Twig.twig,
@@ -83,7 +90,7 @@ module.exports = function (options) {
             return cb(new gutil.PluginError(PLUGIN_NAME, e));
         }
 
-        file.path = rext(file.path, '.html');
+        file.path = data._target.path;
         cb(null, file);
     }
 


### PR DESCRIPTION
Added `changeExt` option to avoid changing file extension to .html (Advanced use cases) , `changeExt` defaults to true so normal cases will change ext to .html and for those who need can avoid changing extension