### PR TITLE
[Feature] Inline Includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ gulp.task('default', ['compile']);
 
 **trace**: [true|false] *enables tracing info logging (defaults to false)*
 
+**includes**: [string|array] *used to pass inline includes to Twig. (defaults to undefined) [Read more here](https://github.com/justjohn/twig.js/wiki#inline-templates) *
+
+**getIncludesId**: [function] *can be used to implement a custom getter for the id (essentially the path) for inline templates passed in `includes`. (defaults to returning `filePath`) [Read more here](https://github.com/justjohn/twig.js/wiki#inline-templates)*
+```javascript
+// default
+function(filePath) {
+    return filePath;
+}
+
+// example implementation
+function(filePath) {
+    return path.relative('./my/source/path', filePath);
+}
+```
+
 **extend**: [function (Twig)] *extends Twig with new tags types. The Twig attribute is Twig.js's internal object. [Read more here](https://github.com/justjohn/twig.js/wiki/Extending-twig.js-With-Custom-Tags)*
 
 **functions**: [array] *extends Twig with given function objects. (default to undefined)*

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var twig = Twig.twig,
 
 module.exports = function (options) {
     'use strict';
+
     options = _.merge({
         data: {},
         includes: null,

--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ var rext = require('replace-ext');
 var gutil = require('gulp-util');
 var glob = require('glob');
 var fs = require('fs');
-var _ = require('lodash');
+var _ = {
+    merge: require('lodash.merge'),
+    isArray: require('lodash.isarray')
+};
 
 const PLUGIN_NAME = 'gulp-twig';
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function (options) {
 
     function modifyContents(file, cb) {
 
-        var data = typeof options.data === 'function' ? options.data(file) : options.data;
+        var data = file.data || (typeof options.data === 'function' ? options.data(file) : options.data);
 
         if (file.isNull()) {
             return cb(null, file);

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
   "author": "Simon de Turck <simon@zimmen.com> (http://www.zimmen.com)",
   "main": "./index.js",
   "dependencies": {
+    "glob": "5.0.6",
     "gulp-util": "^2.2.14",
+    "lodash.isarray": "^3.0.4",
+    "lodash.merge": "^3.3.2",
     "map-stream": "^0.1.0",
     "replace-ext": "0.0.1",
-    "twig": "0.8.2",
-    "lodash": "3.8.0",
-    "glob": "5.0.6"
+    "twig": "0.8.2"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash.merge": "^3.3.2",
     "map-stream": "^0.1.0",
     "replace-ext": "0.0.1",
-    "twig": "0.8.2"
+    "twig": "git://github.com/d-simon/twig.js.git#528dd7ce36e4bdb616c58b786b1a59e646fa24f2"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "gulp-util": "^2.2.14",
     "map-stream": "^0.1.0",
     "replace-ext": "0.0.1",
-    "twig": "0.8.2"
+    "twig": "0.8.2",
+    "lodash": "3.8.0",
+    "glob": "5.0.6"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
I needed this to prepend an include when generating the styleguide [over here](https://github.com/d-simon/for-interaction-by-interaction/blob/develop/theme/gulp/html/default.js#L79).
For this I *integrated inline* includes as implemented in a different [gulp-twig implementation](https://github.com/backflip/gulp-twig/).

A noteworthy change is [line 78 in index.js](https://github.com/zimmen/gulp-twig/compare/master...d-simon:feature/inline-includes?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR78). Instead of passing a file path, the plugin now passes the `file.contents` as string to Twig. This was necessary for my use case. Is there any downside to this?

Secondly, I introduced three dependenies (lodash.merge, lodash.isarray and glob).

And lastly, I have not written any tests for this. Though the current ones are passing.

What are your thoughts on this? :-)

**Important: Not ready to merge!**
To make this work, I had to disable the cache of Twig, which has a very subtle bug with the id of templates (I will open a PR and cross-reference it here).
=> Before anything the bugfix will first have to be approved and make it into a release of Twig.js.