### PR TITLE
Updated twig.js to 0.8.6 and the version number to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-twig",
   "description": "Twig.js plugin for gulp.js (gulpjs.com)",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "http://github.com/zimmen/gulp-twig",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
     "gulp-util": "^2.2.14",
     "map-stream": "^0.1.0",
     "replace-ext": "0.0.1",
-    "twig": "0.8.2"
+    "twig": "0.8.6"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
I'm using the latest version on a project with no issues.

The tests in the repo error (for me) but it appears to just be a line break issue. The new version is adding '\n' after each line in a way that the test don't like. I'm not sure how to resolve it. I am on Windows so perhaps they would pass without error on unix/OSX.