### PR TITLE
update package's node + twigjs versions; update travis's node versions; bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
+  - 4
+  - 6
 before_install:
   - npm install -g istanbul
   - npm install -g codeclimate-test-reporter

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </tr>
 <tr>
 <td>Node Version</td>
-<td>>= 0.10</td>
+<td>>= 4</td>
 </tr>
 <tr>
 <td>Gulp Version</td>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-util": "^3.0.7",
     "map-stream": "^0.1.0",
     "replace-ext": "0.0.1",
-    "twig": "0.10.3"
+    "twig": "^1.10.4"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-twig",
   "description": "Twig.js plugin for gulp.js (gulpjs.com)",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "homepage": "http://github.com/zimmen/gulp-twig",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha -R spec"
   },
   "engines": {
-    "node": ">= 0.9.0"
+    "node": ">=4.0"
   },
   "keywords": [
     "twig",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-util": "^3.0.7",
     "map-stream": "^0.1.0",
     "replace-ext": "0.0.1",
-    "twig": "0.10.0"
+    "twig": "0.10.1"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-util": "^3.0.7",
     "map-stream": "^0.1.0",
     "replace-ext": "0.0.1",
-    "twig": "0.10.1"
+    "twig": "0.10.3"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Updates to the latest twig.js

----

This PR has gotten bigger. Updated description:

The main purpose of this PR is to use the latest 1.x.y version of `twig.js`

`gulp-twig`'s node requirements have fallen far enough behind `twig.js`'s that updating to the latest `twig.js` makes `gulp-twig`'s tests fail. So this PR also updates node in `package.json` and `.travis.yml`.

Upping the node version dependency should be considered a breaking change, so I've bumped to v1. This has the perk of fitting nicely with `twig.js`'s versioning. I propose that `gulp-twig`'s major version should always be the same as the major version of the `twig.js` dependency.